### PR TITLE
Fixes exceptNullValues to not omit fields

### DIFF
--- a/api/src/util/NullValues.ts
+++ b/api/src/util/NullValues.ts
@@ -45,6 +45,8 @@ export function exceptNullValues<T>(value: T): T {
         const fieldValue = value[fieldName];
         if (fieldValue !== undefined && fieldValue !== null) {
             obj[fieldName] = exceptNullValues(fieldValue);
+        } else {
+            obj[fieldName] = undefined;
         }
     }
     return obj as T;


### PR DESCRIPTION
Previously, when iterating over the keys of an object fetched by the generated API, keys where the value was `null` were omitted.
Explicitly set the field to `undefined` if the original field value was `null`. This is in line to array elements being set to `undefined` from `null`.
Additionally, typing does not break, since the original object was typed as `{X:string|null}`, the generated type is {X?:string} and so `undefined` is a valid value for that object.