### PR TITLE
make relay-incopatible types only a warning

### DIFF
--- a/codegen/src/Generator.ts
+++ b/codegen/src/Generator.ts
@@ -44,13 +44,17 @@ export abstract class Generator {
             if (!typeName.startsWith("__")) {
                 const type = typeMap[typeName]!;
                 if (type instanceof GraphQLObjectType || type instanceof GraphQLInterfaceType) {
-                    const tuple = connectionTypeTuple(type);
-                    if (tuple !== undefined) {
-                        connections.set(tuple[0], {
-                            edgeType: tuple[1],
-                            nodeType: tuple[2]
-                        });
-                        edgeTypes.add(tuple[1]);
+                    try {
+                        const tuple = connectionTypeTuple(type);
+                        if (tuple !== undefined) {
+                            connections.set(tuple[0], {
+                                edgeType: tuple[1],
+                                nodeType: tuple[2]
+                            });
+                            edgeTypes.add(tuple[1]);
+                        }
+                    } catch (e) {
+                        console.error(`Cannot get connection type tuple for ${typeName} because: ${e.message}`);
                     }
                 }
                 if (type instanceof GraphQLObjectType || type instanceof GraphQLInterfaceType || type instanceof GraphQLUnionType) {


### PR DESCRIPTION
Thanks for this library! 

I encountered a problem in an API which is nearly relay-compatible but not fully, so this package fails to correctly generate the connection - see error below.

I am proposing to make it only a warning instead of an error. 


```
/home/vojta/projects/my-secret-project/node_modules/graphql-ts-client-codegen/dist/Generator.js:354
                        throw new Error(`The type "${edgeType}" is edge, it must defined a field named "cursor"`);
                              ^

Error: The type "AudioUseEdge" is edge, it must defined a field named "cursor"
    at connectionTypeTuple (/home/vojta/projects/my-secret-project/node_modules/graphql-ts-client-codegen/dist/Generator.js:354:31)
    at AsyncGenerator.<anonymous> (/home/vojta/projects/my-secret-project/node_modules/graphql-ts-client-codegen/dist/Generator.js:55:39)
    at Generator.next (<anonymous>)
    at fulfilled (/home/vojta/projects/my-secret-project/node_modules/graphql-ts-client-codegen/dist/Generator.js:14:58)
```