### PR TITLE
add enum exports

### DIFF
--- a/codegen/dist/CommonTypesWriter.js
+++ b/codegen/dist/CommonTypesWriter.js
@@ -34,7 +34,7 @@ class CommonTypesWriter extends Writer_1.Writer {
         t("export type ImplementationType<T> = ");
         this.enter("BLANK", true);
         for (const [type, castTypes] of this.inheritanceInfo.downcastTypeMap) {
-            if (!(0, Utils_1.isExecludedTypeName)(this.config, type.name)) {
+            if (!Utils_1.isExecludedTypeName(this.config, type.name)) {
                 t("T extends '");
                 t(type.name);
                 t("' ? ");
@@ -45,7 +45,7 @@ class CommonTypesWriter extends Writer_1.Writer {
                     t("'");
                 }
                 for (const castType of castTypes) {
-                    if (!(0, Utils_1.isExecludedTypeName)(this.config, castType.name)) {
+                    if (!Utils_1.isExecludedTypeName(this.config, castType.name)) {
                         this.separator(" | ");
                         t("ImplementationType<'");
                         t(castType.name);
@@ -75,14 +75,14 @@ class CommonTypesWriter extends Writer_1.Writer {
             t("switch (typeName)");
             this.scope({ type: "BLOCK", multiLines: true, suffix: "\n" }, () => {
                 for (const [type, castTypes] of castTypeMap) {
-                    if (!(0, Utils_1.isExecludedTypeName)(this.config, type.name)) {
+                    if (!Utils_1.isExecludedTypeName(this.config, type.name)) {
                         t(`case '${type.name}':`);
                         this.scope({ type: "BLANK", multiLines: true }, () => {
                             if (!(type instanceof graphql_1.GraphQLUnionType)) {
                                 t(`output.push('${type.name}');\n`);
                             }
                             for (const castType of castTypes) {
-                                if (!(0, Utils_1.isExecludedTypeName)(this.config, castType.name)) {
+                                if (!Utils_1.isExecludedTypeName(this.config, castType.name)) {
                                     t(`${prefix}castTypes0('${castType.name}', output);\n`);
                                 }
                             }

--- a/codegen/dist/EnumWriter.js
+++ b/codegen/dist/EnumWriter.js
@@ -33,15 +33,13 @@ class EnumWriter extends Writer_1.Writer {
         t("export enum ");
         t(this.enumType.name);
         t("Enum ");
-        this.enter("BLOCK");
-        this.enter("BLANK", values.length > 3);
+        this.enter("BLOCK", true);
         for (const value of values) {
             t(value.name);
             t(" = '");
             t(value.name);
             t("',\n");
         }
-        this.leave();
         this.leave();
     }
 }

--- a/codegen/dist/EnumWriter.js
+++ b/codegen/dist/EnumWriter.js
@@ -18,10 +18,10 @@ class EnumWriter extends Writer_1.Writer {
     }
     writeCode() {
         const t = this.text.bind(this);
+        const values = this.enumType.getValues();
         t("export type ");
         t(this.enumType.name);
         t(" = ");
-        const values = this.enumType.getValues();
         this.enter("BLANK", values.length > 3);
         for (const value of values) {
             this.separator(" | ");
@@ -29,7 +29,20 @@ class EnumWriter extends Writer_1.Writer {
             t(value.name);
             t("'");
         }
-        this.leave(";\n");
+        this.leave(";\n\n");
+        t("export enum ");
+        t(this.enumType.name);
+        t("Enum ");
+        this.enter("BLOCK");
+        this.enter("BLANK", values.length > 3);
+        for (const value of values) {
+            t(value.name);
+            t(" = '");
+            t(value.name);
+            t("',\n");
+        }
+        this.leave();
+        this.leave();
     }
 }
 exports.EnumWriter = EnumWriter;

--- a/codegen/dist/FetcherWriter.js
+++ b/codegen/dist/FetcherWriter.js
@@ -47,8 +47,8 @@ class FetcherWriter extends Writer_1.Writer {
             const filteredFieldMap = {};
             for (const fieldName in fieldMap) {
                 const field = fieldMap[fieldName];
-                const targetTypeName = (_c = (0, Utils_1.targetTypeOf)(field.type)) === null || _c === void 0 ? void 0 : _c.name;
-                if (!(0, Utils_1.isExecludedTypeName)(config, targetTypeName)) {
+                const targetTypeName = (_c = Utils_1.targetTypeOf(field.type)) === null || _c === void 0 ? void 0 : _c.name;
+                if (!Utils_1.isExecludedTypeName(config, targetTypeName)) {
                     filteredFieldMap[fieldName] = field;
                 }
             }
@@ -60,7 +60,7 @@ class FetcherWriter extends Writer_1.Writer {
         this.hasArgs = false;
         for (const fieldName in this.fieldMap) {
             const field = this.fieldMap[fieldName];
-            const targetType = (0, Utils_1.targetTypeOf)(field.type);
+            const targetType = Utils_1.targetTypeOf(field.type);
             if (this.modelType.name !== "Query" &&
                 this.modelType.name !== "Mutation" &&
                 targetType === undefined &&
@@ -114,7 +114,7 @@ class FetcherWriter extends Writer_1.Writer {
         this.defaultFetcherProps = defaultFetcherProps;
         this.fieldArgsMap = fieldArgsMap;
         this.fieldCategoryMap = fieldCategoryMap;
-        let prefix = (0, Utils_1.instancePrefix)(this.modelType.name);
+        let prefix = Utils_1.instancePrefix(this.modelType.name);
         this.emptyFetcherName = `${prefix}$`;
         this.defaultFetcherName = defaultFetcherProps.length !== 0 ? `${prefix}$$` : undefined;
     }
@@ -131,7 +131,7 @@ class FetcherWriter extends Writer_1.Writer {
         importedFetcherTypeNames.add(this.superFetcherTypeName(this.modelType));
         for (const fieldName in this.fieldMap) {
             const field = this.fieldMap[fieldName];
-            const targetType = (0, Utils_1.targetTypeOf)(field.type);
+            const targetType = Utils_1.targetTypeOf(field.type);
             if (targetType !== undefined) {
                 importedFetcherTypeNames.add(this.superFetcherTypeName(targetType));
             }
@@ -153,7 +153,7 @@ class FetcherWriter extends Writer_1.Writer {
         }
     }
     importedNamesForSuperType(superType) {
-        return [`${(0, Utils_1.instancePrefix)(superType.name)}$`];
+        return [`${Utils_1.instancePrefix(superType.name)}$`];
     }
     importingBehavior(type) {
         if (type === this.modelType) {
@@ -237,7 +237,7 @@ class FetcherWriter extends Writer_1.Writer {
         this.writePositivePropImpl(field, "FULL");
     }
     writeNegativeProp(field) {
-        if (field.args.length !== 0 || (0, Utils_1.targetTypeOf)(field.type) !== undefined) {
+        if (field.args.length !== 0 || Utils_1.targetTypeOf(field.type) !== undefined) {
             return;
         }
         const t = this.text.bind(this);
@@ -254,7 +254,7 @@ class FetcherWriter extends Writer_1.Writer {
         if (withArgs && field.args.length === 0) {
             return;
         }
-        const targetType = (0, Utils_1.targetTypeOf)(field.type);
+        const targetType = Utils_1.targetTypeOf(field.type);
         const withOptions = mode === "WITH_OTPIONS" || mode === "FULL";
         const renderAsField = field.args.length === 0 && targetType === undefined && !withOptions;
         const namePlus = field.args.length === 0 && targetType === undefined && withOptions;
@@ -372,7 +372,7 @@ class FetcherWriter extends Writer_1.Writer {
             t("?");
         }
         t(": ");
-        this.typeRef(field.type, (0, Utils_1.targetTypeOf)(field.type) !== undefined ? "X" : undefined);
+        this.typeRef(field.type, Utils_1.targetTypeOf(field.type) !== undefined ? "X" : undefined);
         t("}");
     }
     writeInstances() {
@@ -408,7 +408,7 @@ class FetcherWriter extends Writer_1.Writer {
                         if (upcastTypes !== undefined) {
                             for (const upcastType of upcastTypes) {
                                 this.separator(", ");
-                                t(`${(0, Utils_1.instancePrefix)(upcastType.name)}$.fetchableType`);
+                                t(`${Utils_1.instancePrefix(upcastType.name)}$.fetchableType`);
                             }
                         }
                     });
@@ -419,7 +419,7 @@ class FetcherWriter extends Writer_1.Writer {
                             this.separator(", ");
                             const args = this.fieldArgsMap.get(declaredFieldName);
                             const category = this.fieldCategoryMap.get(declaredFieldName);
-                            const targetType = (0, Utils_1.targetTypeOf)(field.type);
+                            const targetType = Utils_1.targetTypeOf(field.type);
                             if (args === undefined &&
                                 (category === undefined || category === "SCALAR") &&
                                 field.type instanceof graphql_1.GraphQLNonNull) {

--- a/codegen/dist/Generator.js
+++ b/codegen/dist/Generator.js
@@ -34,13 +34,13 @@ const Utils_1 = require("./Utils");
 class Generator {
     constructor(config) {
         this.config = config;
-        (0, GeneratorConfig_1.validateConfig)(config);
+        GeneratorConfig_1.validateConfig(config);
     }
     generate() {
         var _a;
         return __awaiter(this, void 0, void 0, function* () {
             const schema = yield this.loadSchema();
-            (0, GeneratorConfig_1.validateConfigAndSchema)(this.config, schema);
+            GeneratorConfig_1.validateConfigAndSchema(this.config, schema);
             yield this.rmdirIfNecessary();
             yield this.mkdirIfNecessary();
             const inheritanceInfo = new InheritanceInfo_1.InheritanceInfo(schema);
@@ -63,7 +63,7 @@ class Generator {
                             edgeTypes.add(tuple[1]);
                         }
                     }
-                    if (!(0, Utils_1.isExecludedTypeName)(this.config, type.name)) {
+                    if (!Utils_1.isExecludedTypeName(this.config, type.name)) {
                         if (type instanceof graphql_1.GraphQLObjectType || type instanceof graphql_1.GraphQLInterfaceType || type instanceof graphql_1.GraphQLUnionType) {
                             fetcherTypes.push(type);
                         }
@@ -182,13 +182,13 @@ class Generator {
     }
     generateFetcherTypes(ctx) {
         return __awaiter(this, void 0, void 0, function* () {
-            const dir = (0, path_1.join)(this.config.targetDir, "fetchers");
+            const dir = path_1.join(this.config.targetDir, "fetchers");
             const emptyFetcherNameMap = new Map();
             const defaultFetcherNameMap = new Map();
             const promises = ctx.fetcherTypes
                 .map((type) => __awaiter(this, void 0, void 0, function* () {
                 var _a, _b;
-                const stream = createStreamAndLog((0, path_1.join)(dir, `${type.name}${(_b = (_a = this.config) === null || _a === void 0 ? void 0 : _a.fetcherSuffix) !== null && _b !== void 0 ? _b : "Fetcher"}.ts`));
+                const stream = createStreamAndLog(path_1.join(dir, `${type.name}${(_b = (_a = this.config) === null || _a === void 0 ? void 0 : _a.fetcherSuffix) !== null && _b !== void 0 ? _b : "Fetcher"}.ts`));
                 const writer = this.createFetcheWriter(type, ctx, stream, this.config);
                 emptyFetcherNameMap.set(type, writer.emptyFetcherName);
                 if (writer.defaultFetcherName !== undefined) {
@@ -201,7 +201,7 @@ class Generator {
                 ...promises,
                 (() => __awaiter(this, void 0, void 0, function* () {
                     var _c, _d;
-                    const stream = createStreamAndLog((0, path_1.join)(dir, "index.ts"));
+                    const stream = createStreamAndLog(path_1.join(dir, "index.ts"));
                     for (const type of ctx.fetcherTypes) {
                         const fetcherTypeName = `${type.name}${(_d = (_c = this.config) === null || _c === void 0 ? void 0 : _c.fetcherSuffix) !== null && _d !== void 0 ? _d : "Fetcher"}`;
                         stream.write(`export type {${[
@@ -226,9 +226,9 @@ class Generator {
     }
     generateInputTypes(inputTypes) {
         return __awaiter(this, void 0, void 0, function* () {
-            const dir = (0, path_1.join)(this.config.targetDir, "inputs");
+            const dir = path_1.join(this.config.targetDir, "inputs");
             const promises = inputTypes.map((type) => __awaiter(this, void 0, void 0, function* () {
-                const stream = createStreamAndLog((0, path_1.join)(dir, `${type.name}.ts`));
+                const stream = createStreamAndLog(path_1.join(dir, `${type.name}.ts`));
                 new InputWriter_1.InputWriter(type, stream, this.config).write();
                 yield stream.end();
             }));
@@ -240,9 +240,9 @@ class Generator {
     }
     generateEnumTypes(enumTypes) {
         return __awaiter(this, void 0, void 0, function* () {
-            const dir = (0, path_1.join)(this.config.targetDir, "enums");
+            const dir = path_1.join(this.config.targetDir, "enums");
             const promises = enumTypes.map((type) => __awaiter(this, void 0, void 0, function* () {
-                const stream = createStreamAndLog((0, path_1.join)(dir, `${type.name}.ts`));
+                const stream = createStreamAndLog(path_1.join(dir, `${type.name}.ts`));
                 new EnumWriter_1.EnumWriter(type, stream, this.config).write();
                 yield stream.end();
             }));
@@ -254,21 +254,21 @@ class Generator {
     }
     generateCommonTypes(schema, inheritanceInfo) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = createStreamAndLog((0, path_1.join)(this.config.targetDir, "CommonTypes.ts"));
+            const stream = createStreamAndLog(path_1.join(this.config.targetDir, "CommonTypes.ts"));
             new CommonTypesWriter_1.CommonTypesWriter(schema, inheritanceInfo, stream, this.config).write();
             yield closeStream(stream);
         });
     }
     generateEnumInputMeatadata(schema) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = createStreamAndLog((0, path_1.join)(this.config.targetDir, "EnumInputMetadata.ts"));
+            const stream = createStreamAndLog(path_1.join(this.config.targetDir, "EnumInputMetadata.ts"));
             new EnumInputMetadataWriter_1.EnumInputMetadataWriter(schema, stream, this.config).write();
             yield closeStream(stream);
         });
     }
     writeSimpleIndex(dir, types) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = createStreamAndLog((0, path_1.join)(dir, "index.ts"));
+            const stream = createStreamAndLog(path_1.join(dir, "index.ts"));
             for (const type of types) {
                 stream.write(`export type {${type.name}} from './${type.name}';\n`);
             }
@@ -295,7 +295,7 @@ class Generator {
     mkdirIfNecessary(subDir) {
         return __awaiter(this, void 0, void 0, function* () {
             const dir = subDir !== undefined ?
-                (0, path_1.join)(this.config.targetDir, subDir) :
+                path_1.join(this.config.targetDir, subDir) :
                 this.config.targetDir;
             try {
                 yield accessAsync(dir);
@@ -314,7 +314,7 @@ class Generator {
     }
     writeIndex(schema) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = createStreamAndLog((0, path_1.join)(this.config.targetDir, "index.ts"));
+            const stream = createStreamAndLog(path_1.join(this.config.targetDir, "index.ts"));
             this.writeIndexCode(stream, schema);
             yield closeStream(stream);
         });
@@ -327,12 +327,12 @@ class Generator {
 exports.Generator = Generator;
 function createStreamAndLog(path) {
     console.log(`Write code into file: ${path}`);
-    return (0, fs_1.createWriteStream)(path);
+    return fs_1.createWriteStream(path);
 }
 exports.createStreamAndLog = createStreamAndLog;
 function closeStream(stream) {
     return __awaiter(this, void 0, void 0, function* () {
-        return yield ((0, util_1.promisify)(stream.end).call(stream));
+        return yield (util_1.promisify(stream.end).call(stream));
     });
 }
 exports.closeStream = closeStream;
@@ -391,6 +391,6 @@ function waring(message) {
     console.warn("*************************************************");
     console.log("");
 }
-const mkdirAsync = (0, util_1.promisify)(fs_1.mkdir);
-const rmdirAsync = (0, util_1.promisify)(fs_1.rmdir);
-const accessAsync = (0, util_1.promisify)(fs_1.access);
+const mkdirAsync = util_1.promisify(fs_1.mkdir);
+const rmdirAsync = util_1.promisify(fs_1.rmdir);
+const accessAsync = util_1.promisify(fs_1.access);

--- a/codegen/dist/GeneratorConfig.js
+++ b/codegen/dist/GeneratorConfig.js
@@ -162,7 +162,7 @@ function validateConfigAndSchema(config, schema) {
                 throw new Error(`config.idFieldMap['${typeName}'] is illegal, ` +
                     `there is not field named '${idFieldMap[typeName]}' in the type '${typeName}'`);
             }
-            if ((0, Utils_1.targetTypeOf)(idField.type) !== undefined) {
+            if (Utils_1.targetTypeOf(idField.type) !== undefined) {
                 throw new Error(`config.idFieldMap['${typeName}'] is illegal, ` +
                     `the field '${idFieldMap[typeName]}' of the type '${typeName}' is not scalar`);
             }

--- a/codegen/dist/SchemaLoader.js
+++ b/codegen/dist/SchemaLoader.js
@@ -25,8 +25,8 @@ const utilities_2 = require("graphql/utilities");
 const node_fetch_1 = require("node-fetch");
 function loadRemoteSchema(endpoint, headers) {
     return __awaiter(this, void 0, void 0, function* () {
-        const body = JSON.stringify({ "query": (0, utilities_1.getIntrospectionQuery)() });
-        const response = yield (0, node_fetch_1.default)(endpoint, {
+        const body = JSON.stringify({ "query": utilities_1.getIntrospectionQuery() });
+        const response = yield node_fetch_1.default(endpoint, {
             method: 'POST',
             body,
             headers: Object.assign({ "Accept": "application/json", "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body).toString() }, headers)
@@ -35,14 +35,14 @@ function loadRemoteSchema(endpoint, headers) {
         if (errors !== undefined) {
             throw new Error();
         }
-        return (0, utilities_2.buildClientSchema)(data);
+        return utilities_2.buildClientSchema(data);
     });
 }
 exports.loadRemoteSchema = loadRemoteSchema;
 function loadLocalSchema(location) {
     return __awaiter(this, void 0, void 0, function* () {
-        const sdl = yield (0, promises_1.readFile)(location, { encoding: "utf8" });
-        return (0, utilities_1.buildSchema)(sdl);
+        const sdl = yield promises_1.readFile(location, { encoding: "utf8" });
+        return utilities_1.buildSchema(sdl);
     });
 }
 exports.loadLocalSchema = loadLocalSchema;

--- a/codegen/dist/apollo/ApolloGenerator.js
+++ b/codegen/dist/apollo/ApolloGenerator.js
@@ -33,16 +33,16 @@ class ApolloGenerator extends Generator_1.Generator {
     }
     generateApollo() {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)(this.config.targetDir, "Apollo.ts"));
+            const stream = Generator_1.createStreamAndLog(path_1.join(this.config.targetDir, "Apollo.ts"));
             stream.write(APOLLO_CODE);
-            yield (0, Generator_1.closeStream)(stream);
+            yield Generator_1.closeStream(stream);
         });
     }
     generateDependencyManager() {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)(this.config.targetDir, "DependencyManager.tsx"));
+            const stream = Generator_1.createStreamAndLog(path_1.join(this.config.targetDir, "DependencyManager.tsx"));
             stream.write(DEPENDENCY_MANAGER_CODE);
-            yield (0, Generator_1.closeStream)(stream);
+            yield Generator_1.closeStream(stream);
         });
     }
     writeIndexCode(stream, schema) {

--- a/codegen/dist/async/AsyncGenerator.js
+++ b/codegen/dist/async/AsyncGenerator.js
@@ -32,9 +32,9 @@ class AsyncGenerator extends Generator_1.Generator {
     }
     generateAsync() {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)(this.config.targetDir, "Async.ts"));
+            const stream = Generator_1.createStreamAndLog(path_1.join(this.config.targetDir, "Async.ts"));
             stream.write(ASYNC_CODE);
-            yield (0, Generator_1.closeStream)(stream);
+            yield Generator_1.closeStream(stream);
         });
     }
     writeIndexCode(stream, schema) {

--- a/codegen/dist/relay/RelayGenerator.js
+++ b/codegen/dist/relay/RelayGenerator.js
@@ -28,9 +28,9 @@ class RelayGenerator extends Generator_1.Generator {
     }
     generateRelayCode(schema) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)(this.config.targetDir, "Relay.ts"));
+            const stream = Generator_1.createStreamAndLog(path_1.join(this.config.targetDir, "Relay.ts"));
             new RelayWriter_1.RelayWriter(schema, stream, this.config).write();
-            yield (0, Generator_1.closeStream)(stream);
+            yield Generator_1.closeStream(stream);
         });
     }
     writeIndexCode(stream, schema) {

--- a/codegen/dist/relay/RelayWriter.js
+++ b/codegen/dist/relay/RelayWriter.js
@@ -21,7 +21,7 @@ class RelayWriter extends Writer_1.Writer {
         }
         this.text(relayCode);
         this.text('\nconst typedEnvironment = new TypedEnvironment(`');
-        this.text((0, graphql_1.printSchema)(this.schema));
+        this.text(graphql_1.printSchema(this.schema));
         this.text('`);');
     }
 }

--- a/codegen/dist/state/GraphQLStateFetcherWriter.js
+++ b/codegen/dist/state/GraphQLStateFetcherWriter.js
@@ -43,7 +43,7 @@ class GraphQLStateFetcherWriter extends FetcherWriter_1.FetcherWriter {
                 for (const fieldName of this.declaredFieldNames) {
                     const field = fieldMap[fieldName];
                     const category = this.fieldCategoryMap.get(fieldName);
-                    const targetType = (0, Utils_1.targetTypeOf)(field.type);
+                    const targetType = Utils_1.targetTypeOf(field.type);
                     if (category === "SCALAR") {
                         t("readonly ");
                         t(fieldName);

--- a/codegen/dist/state/GraphQLStateGenerator.js
+++ b/codegen/dist/state/GraphQLStateGenerator.js
@@ -58,30 +58,30 @@ class GraphQLStateGenerator extends Generator_1.Generator {
     }
     generateTypedConfiguration(ctx) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)(this.config.targetDir, "TypedConfiguration.ts"));
+            const stream = Generator_1.createStreamAndLog(path_1.join(this.config.targetDir, "TypedConfiguration.ts"));
             new TypedConfigurationWriter_1.TypedConfigurationWriter(ctx, stream, this.config).write();
-            yield (0, Generator_1.closeStream)(stream);
+            yield Generator_1.closeStream(stream);
         });
     }
     generateTriggerEvents(ctx) {
         return __awaiter(this, void 0, void 0, function* () {
             for (const triggerableType of ctx.triggerableTypes) {
                 const fetcherType = triggerableType;
-                const dir = (0, path_1.join)(this.config.targetDir, "triggers");
-                const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)(dir, `${fetcherType.name}Event.ts`));
+                const dir = path_1.join(this.config.targetDir, "triggers");
+                const stream = Generator_1.createStreamAndLog(path_1.join(dir, `${fetcherType.name}Event.ts`));
                 new TriggerEventWriter_1.TriggerEventWiter(fetcherType, ctx.idFieldMap.get(fetcherType), stream, this.config).write();
-                yield (0, Generator_1.closeStream)(stream);
+                yield Generator_1.closeStream(stream);
             }
         });
     }
     generateTriggerIndex(ctx) {
         return __awaiter(this, void 0, void 0, function* () {
-            const stream = (0, Generator_1.createStreamAndLog)((0, path_1.join)((0, path_1.join)(this.config.targetDir, "triggers"), "index.ts"));
+            const stream = Generator_1.createStreamAndLog(path_1.join(path_1.join(this.config.targetDir, "triggers"), "index.ts"));
             for (const triggerableType of ctx.triggerableTypes) {
                 const fetcherType = triggerableType;
                 stream.write(`export type { ${fetcherType.name}EvictEvent, ${fetcherType.name}ChangeEvent } from './${fetcherType.name}Event';\n`);
             }
-            yield (0, Generator_1.closeStream)(stream);
+            yield Generator_1.closeStream(stream);
         });
     }
 }

--- a/codegen/dist/state/TriggerEventWriter.js
+++ b/codegen/dist/state/TriggerEventWriter.js
@@ -14,8 +14,8 @@ class TriggerEventWiter extends Writer_1.Writer {
         const fieldMap = modelType.getFields();
         for (const fieldName in fieldMap) {
             if (fieldName !== (idField === null || idField === void 0 ? void 0 : idField.name)) {
-                const targetTypeName = (_a = (0, Utils_1.targetTypeOf)(fieldMap[fieldName].type)) === null || _a === void 0 ? void 0 : _a.name;
-                if (!(0, Utils_1.isExecludedTypeName)(config, targetTypeName)) {
+                const targetTypeName = (_a = Utils_1.targetTypeOf(fieldMap[fieldName].type)) === null || _a === void 0 ? void 0 : _a.name;
+                if (!Utils_1.isExecludedTypeName(config, targetTypeName)) {
                     if (fieldMap[fieldName].args.length === 0) {
                         simpleFieldNames.add(fieldName);
                     }

--- a/codegen/dist/state/TypedConfigurationWriter.js
+++ b/codegen/dist/state/TypedConfigurationWriter.js
@@ -35,7 +35,7 @@ class TypedConfigurationWriter extends Writer_1.Writer {
                     eventTypeNames.push(`${fetcherType.name}ChangeEvent`);
                 }
             }
-            instanceNames.push(`${(0, Utils_1.instancePrefix)(fetcherType.name)}$`);
+            instanceNames.push(`${Utils_1.instancePrefix(fetcherType.name)}$`);
         }
         const indent = (_a = this.config.indent) !== null && _a !== void 0 ? _a : "    ";
         const separator = `,\n${indent}`;
@@ -63,7 +63,7 @@ class TypedConfigurationWriter extends Writer_1.Writer {
             this.scope({ type: "PARAMETERS", multiLines: true, suffix: ";\n" }, () => {
                 for (const fetcherType of this.ctx.fetcherTypes) {
                     this.separator(", ");
-                    t((0, Utils_1.instancePrefix)(fetcherType.name));
+                    t(Utils_1.instancePrefix(fetcherType.name));
                     t("$");
                 }
             });
@@ -144,9 +144,9 @@ class TypedConfigurationWriter extends Writer_1.Writer {
         const fieldMap = fetcherType.getFields();
         for (const fieldName in fieldMap) {
             const field = fieldMap[fieldName];
-            const targetType = (0, Utils_1.targetTypeOf)(field.type);
+            const targetType = Utils_1.targetTypeOf(field.type);
             if (targetType !== undefined &&
-                !(0, Utils_1.isExecludedTypeName)(this.config, targetType.name) &&
+                !Utils_1.isExecludedTypeName(this.config, targetType.name) &&
                 !this.ctx.embeddedTypes.has(targetType)) {
                 const connection = this.ctx.connections.get(targetType);
                 if (connection !== undefined) {

--- a/codegen/src/EnumWriter.ts
+++ b/codegen/src/EnumWriter.ts
@@ -45,15 +45,13 @@ export class EnumWriter extends Writer {
         t(this.enumType.name);
         t("Enum ");
 
-        this.enter("BLOCK");
-        this.enter("BLANK", values.length > 3);
+        this.enter("BLOCK", true);
         for (const value of values) {
             t(value.name);
             t(" = '");
             t(value.name);
             t("',\n");
         }
-        this.leave();
         this.leave();
     }
 }

--- a/codegen/src/EnumWriter.ts
+++ b/codegen/src/EnumWriter.ts
@@ -1,8 +1,8 @@
 /**
  * @author ChenTao
- * 
+ *
  * 'graphql-ts-client' is a graphql client for TypeScript, it has two functionalities:
- * 
+ *
  * 1. Supports GraphQL queries with strongly typed code
  *
  * 2. Automatically infers the type of the returned data according to the strongly typed query
@@ -24,14 +24,14 @@ export class EnumWriter extends Writer {
     }
 
     protected writeCode() {
-        
+
         const t = this.text.bind(this);
+        const values = this.enumType.getValues();
 
         t("export type ");
         t(this.enumType.name);
         t(" = ");
 
-        const values = this.enumType.getValues();
         this.enter("BLANK", values.length > 3);
         for (const value of values) {
             this.separator(" | ");
@@ -39,6 +39,21 @@ export class EnumWriter extends Writer {
             t(value.name);
             t("'");
         }
-        this.leave(";\n");
+        this.leave(";\n\n");
+
+        t("export enum ");
+        t(this.enumType.name);
+        t("Enum ");
+
+        this.enter("BLOCK");
+        this.enter("BLANK", values.length > 3);
+        for (const value of values) {
+            t(value.name);
+            t(" = '");
+            t(value.name);
+            t("',\n");
+        }
+        this.leave();
+        this.leave();
     }
 }


### PR DESCRIPTION
I've been playing with this library and enjoying it quite a bit.

This change gives access to the enums from the graphql schema outside of graphql-ts-client as an enum.  

I just ran `tsc` to compile, not sure why it changed the files that were not updated, perhaps a typescript update within the semver specified.